### PR TITLE
fix compress_field import and argument with reserved name

### DIFF
--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ htmlcov/
 .tox/
 .coverage
 .cache
+.eggs
 nosetests.xml
 coverage.xml
 
@@ -57,3 +58,7 @@ docs/_build/
 
 README.rst
 .DS_Store
+
+.venv
+.autoenv
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: python
 python:
-  - 2.7
-script: python setup.py test
+  - 3.7
+script: python setup.py pytest
 env:
-  - DJANGO=1.4
-  - DJANGO=1.5
-  - DJANGO=1.6
-  - DJANGO=1.7
-  - DJANGO=1.8
-  - DJANGO=1.9
-  - DJANGO=1.10
   - DJANGO=1.11
+  - DJANGO=2.1
+  - DJANGO=3.0
 install:
   - pip install -q Django==$DJANGO -r requirements.txt
 branches:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ or by source code
     git clone https://github.com/valdergallo/django-compress-field/
     python setup.py install
 ```
-or 
+or
 ```
     pip install git+https://github.com/valdergallo/django-compress-field.git
 ```
@@ -149,7 +149,7 @@ git clone https://github.com/valdergallo/django-compress-field
 setup.py develop
 
 # test project
-setup.py test
+pytest .
 
 #clean extra content
 setup.py clean

--- a/compress_field/__init__.py
+++ b/compress_field/__init__.py
@@ -1,2 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.10.1'
+__version__ = '0.10.2'
+
+from .models import ZipFileField
+from .fieldfiles import ZipCompressFieldFile

--- a/compress_field/__init__.py
+++ b/compress_field/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.10.2'
+__version__ = "0.10.2"
 
 from .models import ZipFileField
 from .fieldfiles import ZipCompressFieldFile

--- a/compress_field/base.py
+++ b/compress_field/base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+
 try:
     from celery.task import task
 except ImportError:
@@ -15,8 +16,7 @@ except ImportError:
 from django.db.models.fields.files import FieldFile
 
 
-FILE_COMPRESS_DELETE_OLD_FILE = getattr(settings,
-                                        'FILE_COMPRESS_DELETE_OLD_FILE', True)
+FILE_COMPRESS_DELETE_OLD_FILE = getattr(settings, "FILE_COMPRESS_DELETE_OLD_FILE", True)
 
 
 class CompressFieldFile(FieldFile):
@@ -24,18 +24,20 @@ class CompressFieldFile(FieldFile):
 
     def _is_compressed(self):
         basename, ext = os.path.splitext(self.name)
-        compress_ext = '.' + self.compress_ext
+        compress_ext = "." + self.compress_ext
         return compress_ext == ext
+
     is_compressed = property(_is_compressed)
 
     def _base_name(self):
         return os.path.basename(self.file.name)
+
     base_name = property(_base_name)
 
     def _compress_name(self):
-        if not hasattr(self, '_avaliable_compress_name'):
+        if not hasattr(self, "_avaliable_compress_name"):
             basename, ext = os.path.splitext(self.name)
-            compress_name = basename + ('.' + self.compress_ext)
+            compress_name = basename + ("." + self.compress_ext)
             self._avaliable_compress_name = self.storage.get_available_name(
                 compress_name
             )
@@ -75,12 +77,14 @@ class CompressFieldFile(FieldFile):
 
     def compress(self, async_task=True, delete_old_file=FILE_COMPRESS_DELETE_OLD_FILE):
         if self.is_compressed:
-            return 'This file is alredy compress'
+            return "This file is alredy compress"
 
         if async_task and task:
             from .tasks import task_compress_wrapper
+
             wrapper = task_compress_wrapper.delay(
-                self.instance, self.field.name, delete_old_file)
+                self.instance, self.field.name, delete_old_file
+            )
         else:
             wrapper = CompressFieldFile.compress_wrapper(self, delete_old_file)
 

--- a/compress_field/base.py
+++ b/compress_field/base.py
@@ -73,12 +73,11 @@ class CompressFieldFile(FieldFile):
         self._update_filefield_name(delete_old_file=delete_old_file)
         return True
 
-    def compress(self, async=True,
-                 delete_old_file=FILE_COMPRESS_DELETE_OLD_FILE):
+    def compress(self, async_task=True, delete_old_file=FILE_COMPRESS_DELETE_OLD_FILE):
         if self.is_compressed:
             return 'This file is alredy compress'
 
-        if async and task:
+        if async_task and task:
             from .tasks import task_compress_wrapper
             wrapper = task_compress_wrapper.delay(
                 self.instance, self.field.name, delete_old_file)

--- a/compress_field/fieldfiles.py
+++ b/compress_field/fieldfiles.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import zipfile
 import sys
 from .base import CompressFieldFile
+
 try:
     compression = zipfile.ZIP_DEFLATED
 except ImportError:
@@ -10,18 +11,19 @@ except ImportError:
 
 
 class ZipCompressFieldFile(CompressFieldFile):
-    compress_ext = 'zip'
+    compress_ext = "zip"
 
     def compress_content(self):
         compress_file_fullname = self.compress_full_name
 
         # to work with py2.6 or lower
         if sys.version_info < (2, 7):
-            compress_file_fullname = open(compress_file_fullname, 'w+b')
+            compress_file_fullname = open(compress_file_fullname, "w+b")
 
         if not zipfile.is_zipfile(self.file.name):
             ziped = zipfile.ZipFile(
-                compress_file_fullname, 'w', compression=compression)
+                compress_file_fullname, "w", compression=compression
+            )
             ziped.write(self.file.name, self.base_name)
             ziped.close()
             return ziped

--- a/compress_field/models.py
+++ b/compress_field/models.py
@@ -8,14 +8,16 @@ class ZipFileField(models.FileField):
     """
     ZipField - auto zip content after file was saved on server
     """
+
     attr_class = ZipCompressFieldFile
 
     def south_field_triple(self):
         try:
             from south.modelsinspector import introspector
-            cls_name = '{0}.{1}'.format(
-                self.__class__.__module__,
-                self.__class__.__name__)
+
+            cls_name = "{0}.{1}".format(
+                self.__class__.__module__, self.__class__.__name__
+            )
             args, kwargs = introspector(self)
             return cls_name, args, kwargs
         except ImportError:
@@ -24,6 +26,7 @@ class ZipFileField(models.FileField):
 
 try:
     from south.modelsinspector import add_introspection_rules
+
     add_introspection_rules([], ["^compress_field\.models\.(ZipFileField)"])
 except ImportError:
     pass

--- a/compress_field/tasks.py
+++ b/compress_field/tasks.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+
 try:
     from celery.task import task
 except ImportError:
     task = None
 
 from django.core.cache import cache
+
 LOCK_EXPIRE = 60 * 5
 
 try:
@@ -13,12 +15,12 @@ try:
 except ImportError:
     settings = {}
 
-FILE_COMPRESS_QUEUE = getattr(settings, 'FILE_COMPRESS_QUEUE', 'Celery')
+FILE_COMPRESS_QUEUE = getattr(settings, "FILE_COMPRESS_QUEUE", "Celery")
 
 
 # cache.add fails if if the key already exists
 def acquire_lock(lock_id):
-    return cache.add(lock_id, 'true', LOCK_EXPIRE)
+    return cache.add(lock_id, "true", LOCK_EXPIRE)
 
 
 # memcache delete is very slow, but we have to use it to take
@@ -27,10 +29,9 @@ def release_lock(lock_id):
     return cache.delete(lock_id)
 
 
-@task(serializer='pickle', queue=FILE_COMPRESS_QUEUE)
+@task(serializer="pickle", queue=FILE_COMPRESS_QUEUE)
 def task_compress_wrapper(instance, field, delete_old_file):
-    lock_id = '{0}-io-lock-{1}'.format(
-        instance.__class__.__name__, instance.id)
+    lock_id = "{0}-io-lock-{1}".format(instance.__class__.__name__, instance.id)
 
     if acquire_lock(lock_id):
         instance_field = getattr(instance, field)
@@ -39,5 +40,5 @@ def task_compress_wrapper(instance, field, delete_old_file):
         return True
 
     # task is locked by IO
-    print('IO Lock Task')
+    print("IO Lock Task")
     return False

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+def pytest_configure():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_test_settings')
+

--- a/example/apps.py
+++ b/example/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class ExampleConfig(AppConfig):
+    name = 'example'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+addopts = --cov=compress_field  -vrsx
+testpaths =
+    compress_field
+    tests
+    example

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-pytest==3.0.2
-pytest-cov==2.3.1
-pytest-django==2.9.1
+coverage==5.2
+pytest==5.4.3
+pytest-cov==2.10.0
+pytest-django==3.9.0
+pytest-runner==5.2

--- a/setup.py
+++ b/setup.py
@@ -13,23 +13,12 @@ install_requires = [
 
 tests_requires = [
     'django>=1.2',
-    'pytest==3.0.2',
-    'pytest-django==2.9.1',
-    'pytest-cov==2.3.1',
+    'pytest>=3.0.2',
+    'pytest-runner',
+    'pytest-django>=2.9.1',
+    'pytest-cov>=2.3.1',
 ]
 
-
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = ['compress_field', 'tests', '--cov=compress_field', '-vrsx']
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
 
 
 def readme():
@@ -58,12 +47,13 @@ setup(name='django-compress-field',
           'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
       ],
       include_package_data=True,
       version=compress_field.__version__,
       install_requires=install_requires,
       tests_require=tests_requires,
-      cmdclass={'test': PyTest},
+      setup_requires=['pytest-runner'],
       platforms='any',
       packages=[
             'compress_field'


### PR DESCRIPTION
* rename reserved name in argument

* add imports in `__init__.py` for migrations works

* Add support for Django 3.0.8 and python 3.7

Solving problem reported in (Import error related to Zip file field  #9)